### PR TITLE
Update build.sh

### DIFF
--- a/packages/cronie/build.sh
+++ b/packages/cronie/build.sh
@@ -40,5 +40,6 @@ termux_step_create_debscripts() {
 	mkdir -p $TERMUX_PREFIX/var/run
 	mkdir -p $TERMUX_PREFIX/var/spool/cron
 	mkdir -p $TERMUX_PREFIX/etc/cron.d
+	mkdir -p $TERMUX_PREFIX/.cache
 	EOF
 }


### PR DESCRIPTION
To avoid this error message:

> crontab -e
crontab: installing new crontab
/data/data/com.termux/files/home/.cache/crontab: mkdir: No such file or directory